### PR TITLE
Wrap new URL(opts.uri) in try/catch in awsIamSignedRequest. Closes #27

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,12 @@ const awsIamSignedRequest = (opts, service, credentials, callback) => {
   };
 
   // Parse the URL to get the hostname and path
-  const url = new URL(opts.uri);
+  let url;
+  try {
+    url = new URL(opts.uri);
+  } catch (e) {
+    return callback(e);
+  }
   const hostname = url.hostname;
   const path = url.pathname + url.search;
 
@@ -248,7 +253,7 @@ const awsIamSignedRequest = (opts, service, credentials, callback) => {
     method: opts.method,
     headers: {
       ...opts.headers,
-      host: new URL(opts.uri).hostname.toString(),
+      host: hostname,
     },
     body: opts.body ? JSON.stringify(opts.body) : null,
     service: service,

--- a/test/awsIamSignedRequest.test.js
+++ b/test/awsIamSignedRequest.test.js
@@ -196,6 +196,26 @@ describe("awsIamSignedRequest", () => {
     });
   });
 
+  it("should call callback with error when URI is invalid", (done) => {
+    const opts = {
+      uri: "not-a-valid-url",
+      method: "GET",
+      headers: {},
+    };
+
+    const credentials = {
+      AccessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      SessionToken: "testSessionToken",
+    };
+
+    taws.awsIamSignedRequest(opts, "execute-api", credentials, (error) => {
+      expect(error).to.exist;
+      expect(error).to.be.an.instanceOf(TypeError);
+      done();
+    });
+  });
+
   it("should call callback with error on non-JSON response", (done) => {
     nock("https://execute-api.us-east-1.amazonaws.com").get("/test").reply(200, "not json", {
       "Content-Type": "text/plain",

--- a/test/awsIamSignedRequest.test.js
+++ b/test/awsIamSignedRequest.test.js
@@ -211,7 +211,7 @@ describe("awsIamSignedRequest", () => {
 
     taws.awsIamSignedRequest(opts, "execute-api", credentials, (error) => {
       expect(error).to.exist;
-      expect(error).to.be.an.instanceOf(TypeError);
+      expect(error.name).to.equal("TypeError");
       done();
     });
   });


### PR DESCRIPTION
Closes #27

## Summary
Wrap `new URL(opts.uri)` in try/catch so invalid URIs call the callback with an error instead of throwing an uncaught exception.